### PR TITLE
Add links to OSGeoLive branding

### DIFF
--- a/marketing/branding/subbrands/README.md
+++ b/marketing/branding/subbrands/README.md
@@ -27,7 +27,7 @@ To use the template you will need to:
 The sub-brands listed in these folders were generated at the start of the website/rebranding process. Many of these did not end up being used either on the website or by their respective communities.
 
 * GeoForAll decided not to use an OSGeo sub-brand, opting instead update their logo by maintaining their distinct emblem and adopting the new OSGeo font and branding colors
-* OSGeo Live also decided to adopt a distinct brand with their own emblem and OSGeo font and branding colors
+* OSGeoLive also decided to adopt a distinct brand with their own emblem and OSGeo font and branding colors. OSGeoLive branding is maintained in the [OSGeoLive documentation repository](https://github.com/OSGeo/OSGeoLive-doc/tree/master/images/osgeolive-logo).
 * Case-Studies were replaced by resources on the website in order to attract a wider range of contributions from our community. This idea did not represent require a subbrand.
 
 Consider these folders to contain examples of using the subbrand template and check with the respective community before use.

--- a/marketing/branding/subbrands/live/README.md
+++ b/marketing/branding/subbrands/live/README.md
@@ -3,3 +3,5 @@
 The OSGeoLive project has decided not to use this subbrand and adopt a distinct brand that more accurately reflects their projects function.
 
 OSGeoLive branding is maintained in the [OSGeoLive documentation repository](https://github.com/OSGeo/OSGeoLive-doc/tree/master/images/osgeolive-logo).
+
+![OSGeoLive Logo](https://raw.githubusercontent.com/OSGeo/OSGeoLive-doc/master/images/osgeolive-logo/osgeolive-logo.png)

--- a/marketing/branding/subbrands/live/README.md
+++ b/marketing/branding/subbrands/live/README.md
@@ -1,3 +1,5 @@
-# OSGeo Live
+# OSGeoLive
 
-The OSGeo Live project has decided not to use this subbrand and adopt a distinct brand that more accurately reflects their projects function.
+The OSGeoLive project has decided not to use this subbrand and adopt a distinct brand that more accurately reflects their projects function.
+
+OSGeoLive branding is maintained in the [OSGeoLive documentation repository](https://github.com/OSGeo/OSGeoLive-doc/tree/master/images/osgeolive-logo).


### PR DESCRIPTION
Matches latest discussion in which project was named "OSGeoLive":
https://lists.osgeo.org/pipermail/live-demo/2017-November/012873.html
http://irclogs.geoapt.com/osgeolive/%23osgeolive.2017-11-06.log

Links will work when https://github.com/OSGeo/OSGeoLive-doc/pull/339 is merged.